### PR TITLE
Add SBTC fork params

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -290,6 +290,63 @@ var BC2NetParams = Params{
 	HDCoinType: 2,
 }
 
+// BTGNetParams are the parameters for the Super Bitcoin network
+var SBTCNetParams = Params{
+	Name:        "btg",
+	Net:         wire.MainNet, // yup they use the same magic.
+	DefaultPort: "8334",
+
+	DNSSeeds: []string{
+		"seed.superbtc.org",
+		"seed.superbtca.info",
+		"seed.superbtc.org",
+	},
+
+	// Chain parameters
+	GenesisBlock:             &genesisBlock,
+	GenesisHash:              &genesisHash,
+	PowLimit:                 mainPowLimit,
+	PowLimitBits:             0x1d00ffff,
+	CoinbaseMaturity:         100,
+	SubsidyReductionInterval: 210000,
+	TargetTimespan:           time.Hour * 24 * 14, // 14 days
+	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
+	RetargetAdjustmentFactor: 4,                   // 25% less, 400% more
+	ReduceMinDifficulty:      false,
+	MinDiffReductionTime:     0,
+	GenerateSupported:        false,
+
+	// Checkpoints ordered from oldest to newest.
+	Checkpoints: []Checkpoint{},
+
+	// Enforce current block version once majority of the network has
+	// upgraded.
+	// 51% (51 / 100)
+	// Reject previous block versions once a majority of the network has
+	// upgraded.
+	// 75% (75 / 100)
+	BlockEnforceNumRequired: 51,
+	BlockRejectNumRequired:  75,
+	BlockUpgradeNumToCheck:  100,
+
+	// Mempool parameters
+	RelayNonStdTxs: true,
+
+	// Address encoding magics
+	PubKeyHashAddrID: 0x00,   // starts with 1
+	ScriptHashAddrID: 0x05,   // starts with 3
+	PrivateKeyID:     0x80,   // starts with 5 (uncompressed) or K (compressed)
+	Bech32Prefix:     "sbtc", // I guess
+
+	// BIP32 hierarchical deterministic extended key magics
+	HDPrivateKeyID: [4]byte{0x04, 0x35, 0x83, 0x94}, // starts with tprv
+	HDPublicKeyID:  [4]byte{0x04, 0x35, 0x87, 0xcf}, // starts with tpub
+
+	// BIP44 coin type used in the hierarchical deterministic path for
+	// address generation.
+	HDCoinType: 0,
+}
+
 // BTGNetParams are the parameters for the bitcoin gold network
 // This network forked off in november 2017 or so; seems similar to mainnet
 // and bitcoin cash; but has a forkID flag set to


### PR DESCRIPTION
I guess most of the stuff is the same as in main net. Apparently, there's a difficulty change, denoted by a `consensus.SBTCdifDec = 26000;`, I'll update the PR after finding more about it.